### PR TITLE
Added confirmation message to customize MDN message

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -13,7 +13,7 @@ class PartnerAdmin(admin.ModelAdmin):
     list_filter = ('name','as2_name')
     fieldsets = (
         (None, {
-            'fields': ('name', 'as2_name', 'email_address','target_url','subject','content_type')
+            'fields': ('name', 'as2_name', 'email_address','target_url','subject','content_type', 'confirmation_message')
         }),
         ('Http Authentication', {
             'classes': ('collapse','wide'),

--- a/as2lib.py
+++ b/as2lib.py
@@ -131,7 +131,21 @@ def build_mdn(message, status, **kwargs):
     try:
         hparser = HeaderParser()
         message_header = hparser.parsestr(message.headers)
+
+        # default message
         text = _(u'The AS2 message has been processed. Thank you for exchanging AS2 messages with Pyas2.')
+
+        # check for default orginization message
+        if message.organization.confirmation_message:
+            text = message.organization.confirmation_message
+
+        # overwrite with partner specific message
+        if message.partner.confirmation_message:
+            text = message.partner.confirmation_message
+
+        if text == None:
+            text = _(u'The AS2 message has been processed. Thank you for exchanging AS2 messages with Pyas2.')
+
         if status != 'success':
             #### Send mail here
             as2utils.senderrorreport(message, _(u'Failure in processing message from partner,\n Basic status : %s \n Advanced Status: %s'%(kwargs['adv_status'],kwargs['status_message'])))

--- a/as2lib.py
+++ b/as2lib.py
@@ -132,8 +132,7 @@ def build_mdn(message, status, **kwargs):
         hparser = HeaderParser()
         message_header = hparser.parsestr(message.headers)
 
-        # default message
-        text = _(u'The AS2 message has been processed. Thank you for exchanging AS2 messages with Pyas2.')
+        text = str()
 
         # check for default orginization message
         if message.organization.confirmation_message:
@@ -143,7 +142,8 @@ def build_mdn(message, status, **kwargs):
         if message.partner.confirmation_message:
             text = message.partner.confirmation_message
 
-        if text == None:
+        # default message
+        if text.strip() == '':
             text = _(u'The AS2 message has been processed. Thank you for exchanging AS2 messages with Pyas2.')
 
         if status != 'success':

--- a/models.py
+++ b/models.py
@@ -31,6 +31,7 @@ class PublicCertificate(models.Model):
 
 class Organization(models.Model):
     name = models.CharField(verbose_name=_('Organization Name'),max_length=100)
+    confirmation_message = models.CharField(verbose_name=_('Confirmation Message'),max_length=300, null=True, blank=True)
     as2_name = models.CharField(verbose_name=_('AS2 Identifier'),max_length=100, primary_key=True)
     email_address = models.EmailField(null=True, blank=True)
     encryption_key = models.ForeignKey(PrivateCertificate, related_name='enc_org', null=True, blank=True) 
@@ -60,6 +61,7 @@ class Partner(models.Model):
         ('SYNC', 'Synchronous'),
         ('ASYNC', 'Asynchronous'),
     )
+    confirmation_message = models.CharField(verbose_name=_('Confirmation Message'),max_length=300, null=True, blank=True)
     name = models.CharField(verbose_name=_('Partner Name'),max_length=100)
     as2_name = models.CharField(verbose_name=_('AS2 Identifier'),max_length=100, primary_key=True)
     email_address = models.EmailField(null=True, blank=True)


### PR DESCRIPTION
To address issue #20. MDN confirmation message customization. The message isn't used in processing, but it is something a business partner or customer might see. The user should be able to customize it. I also want to modify the message, and it was fairly easy to implement.
- Added confirmation_message to Partner and Organization models.
- Organization message overwrites default message for all partners.
- Partner message overwrites organization and default message for partner-specific messages.
- If the message isn't configured for partner or organization the default message is used.
